### PR TITLE
Added Smalltalk example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
 <a href="https://hub.docker.com/r/100hellos" alt="DockerHub!">
-    <img src="https://img.shields.io/badge/Hello%20World!-65_to_go-red"
+    <img src="https://img.shields.io/badge/Hello%20World!-64_to_go-red"
         height="130"></a>
 </p>
 

--- a/smalltalk/Dockerfile
+++ b/smalltalk/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+# escape=\
+FROM 100hellos/000-base:local
+
+RUN sudo \
+  apk add --no-cache \
+    gawk \
+    zip \
+    patch
+
+COPY --chown=human:human ./artifacts /artifacts
+RUN cd /artifacts && make install
+
+COPY --chown=human:human ./files /hello-world

--- a/smalltalk/Makefile
+++ b/smalltalk/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.language-container.mk

--- a/smalltalk/README.md
+++ b/smalltalk/README.md
@@ -1,0 +1,11 @@
+# Smalltalk
+
+Quoting [Wikipedia](https://en.wikipedia.org/wiki/Smalltalk):
+
+> Smalltalk is a purely object oriented programming language (OOP), which was originally created in the 1970s for educational use, specifically for constructionist learning, but later found use in business. It was created at Xerox PARC by Learning Research Group (LRG) scientists, including Alan Kay, Dan Ingalls, Adele Goldberg, Ted Kaehler, Diana Merry, and Scott Wallace. 
+>
+> In Smalltalk, executing programs are built of opaque, atomic, so-called objects, which are instances of template code stored in classes. These objects intercommunicate by passing of messages, via an intermediary virtual machine environment (VM). A relatively small number of objects, called primitives, are not amenable to live redefinition, sometimes being defined independently of the Smalltalk programming environment. 
+
+Smalltalk is notable for influencing a wide range of languages, including Ruby and Crystal, which both copy a lot of Smalltalk's syntax and idioms.
+
+In this container we make use of the GNU Smalltalk implementation of Smalltalk-80 to demonstrate a simple program which defines a class, instantiates it, and sends it a message.

--- a/smalltalk/artifacts/Makefile
+++ b/smalltalk/artifacts/Makefile
@@ -1,0 +1,9 @@
+install:
+	wget https://ftp.gnu.org/gnu/smalltalk/smalltalk-3.2.tar.xz
+	tar -xvf smalltalk-3.2.tar.xz
+	rm smalltalk-3.2.tar.xz
+	patch -p0 < support-musl.patch
+	cd smalltalk-3.2 && CFLAGS=-std=gnu89 ./configure --prefix=$(HOME)/.local --disable-generational-gc --without-emacs
+	cd smalltalk-3.2 && make
+	cd smalltalk-3.2 && make install
+	rm -rf smalltalk-3.2

--- a/smalltalk/artifacts/support-musl.patch
+++ b/smalltalk/artifacts/support-musl.patch
@@ -1,0 +1,15 @@
+--- smalltalk-3.2/libgst/callin.c	2010-04-21 03:25:01.000000000 -0600
++++ smalltalk-3.2/libgst/callin.c	2023-11-27 20:48:15.236308417 -0700
+@@ -99,11 +99,7 @@
+   if (!_gst_smalltalk_initialized)
+     _gst_initialize (NULL, NULL, GST_NO_TTY);
+ 
+-#ifdef __va_copy
+-  __va_copy (save, ap);
+-#else
+-  save = ap;
+-#endif
++  va_copy(save, ap);
+ 
+   for (numArgs = 0; (anArg = va_arg (ap, OOP)) != NULL; numArgs++);
+ 

--- a/smalltalk/files/hello-world.sh
+++ b/smalltalk/files/hello-world.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+gst hello-world.st

--- a/smalltalk/files/hello-world.st
+++ b/smalltalk/files/hello-world.st
@@ -1,6 +1,6 @@
 Object subclass: Hello [
   greet [
-    'Hello, world' displayNl
+    'Hello World!' displayNl
   ]
 ].
 

--- a/smalltalk/files/hello-world.st
+++ b/smalltalk/files/hello-world.st
@@ -1,0 +1,8 @@
+Object subclass: Hello [
+  greet [
+    'Hello, world' displayNl
+  ]
+].
+
+greeting := Hello new.
+greeting greet.


### PR DESCRIPTION
This implementation of what is, as of this writing, the most recent stable version of GNU Smalltalk and builds it from source.

Of course, this isn't without it's challenges.  Because Alpine uses musl and not glibc, the code doesn't immediately compile due to use of the now-deprecated __va_copy function, so I've included a patch to replace that usage with regular va_copy, which gets the code compiled in c89 mode for GCC 12.

As for the example, I made it slightly more elaborate than strictly necessary.  I could've just called displayNl on a string, but what fun is that?  Smalltalk is one of the original OO languages, so not including an example that defines a class, instantiates it, and sends it a message would be just silly, wouldn't it?